### PR TITLE
Only target .netstandard

### DIFF
--- a/src/NServiceBus.Extensions.DependencyInjection/NServiceBus.Extensions.DependencyInjection.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection/NServiceBus.Extensions.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
@@ -9,9 +9,6 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="[7.2.0, 8.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Particular.CodeRules" Version="0.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.3.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
I don't think there is a need to explicitly target .NET FW 4.6