### PR TITLE
Make extension method discoverable

### DIFF
--- a/src/NServiceBus.Extensions.DependencyInjection.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Extensions.DependencyInjection.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1,4 +1,4 @@
-namespace NServiceBus.Extensions.DependencyInjection
+namespace NServiceBus
 {
     public class static ServiceCollectionExtensions
     {

--- a/src/NServiceBus.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/NServiceBus.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,8 +1,8 @@
-﻿namespace NServiceBus.Extensions.DependencyInjection
+﻿namespace NServiceBus
 {
+    using Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
-    using NServiceBus;
 
     /// <summary>
     /// Extensions methods to configure an IServiceCollection for NServiceBus.


### PR DESCRIPTION
Move `.AddNServiceBus` to the `NServiceBus` namespace.