### PR TITLE
Remove Microsoft.Extensions.DependencyInjection dependency from tests

### DIFF
--- a/src/NServiceBus.Extensions.DependencyInjection.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.AcceptanceTests.csproj
@@ -10,7 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.2.2" />
   </ItemGroup>
 

--- a/src/NServiceBus.Extensions.DependencyInjection.Autofac.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.Autofac.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection.Autofac.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.Autofac.AcceptanceTests.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.2.2" />
   </ItemGroup>
 

--- a/src/NServiceBus.Extensions.DependencyInjection.CastleWindsor.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.CastleWindsor.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection.CastleWindsor.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.CastleWindsor.AcceptanceTests.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="3.3.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.2.2" />
   </ItemGroup>
 

--- a/src/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="4.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.2.2" />
   </ItemGroup>
 

--- a/src/NServiceBus.Extensions.DependencyInjection.StructureMap.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.StructureMap.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection.StructureMap.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.StructureMap.AcceptanceTests.csproj
@@ -10,7 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.2.2" />
     <PackageReference Include="StructureMap.Microsoft.DependencyInjection" Version="2.0.0" />
   </ItemGroup>

--- a/src/NServiceBus.Extensions.DependencyInjection.Tests/NServiceBus.Extensions.DependencyInjection.Tests.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection.Tests/NServiceBus.Extensions.DependencyInjection.Tests.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
     <PackageReference Include="NServiceBus" Version="7.2.2" />
     <PackageReference Include="Particular.Approvals" Version="0.2.0" />
     <PackageReference Include="PublicApiGenerator" Version="9.3.0" />

--- a/src/NServiceBus.Extensions.DependencyInjection.Unity.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.Unity.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection.Unity.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.Unity.AcceptanceTests.csproj
@@ -10,7 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.2.2" />
     <PackageReference Include="Unity.Microsoft.DependencyInjection" Version="5.11.5" />
   </ItemGroup>


### PR DESCRIPTION
Is there any reason why we would need to explicitly specify the dependency to the MS package unless the dependencies run into a version conflict?