### PR TITLE
Make test target netcoreapp3.1 instead of netcoreapp2.1

### DIFF
--- a/src/NServiceBus.Extensions.DependencyInjection.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/NServiceBus.Extensions.DependencyInjection.Autofac.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.Autofac.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection.Autofac.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.Autofac.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/NServiceBus.Extensions.DependencyInjection.CastleWindsor.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.CastleWindsor.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection.CastleWindsor.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.CastleWindsor.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests.csproj
@@ -9,9 +9,15 @@
     <ProjectReference Include="..\NServiceBus.Extensions.DependencyInjection\NServiceBus.Extensions.DependencyInjection.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="4.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.2.3" />
   </ItemGroup>
 

--- a/src/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="4.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.2.3" />
   </ItemGroup>
 

--- a/src/NServiceBus.Extensions.DependencyInjection.StructureMap.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.StructureMap.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection.StructureMap.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.StructureMap.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/NServiceBus.Extensions.DependencyInjection.Tests/NServiceBus.Extensions.DependencyInjection.Tests.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection.Tests/NServiceBus.Extensions.DependencyInjection.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/NServiceBus.Extensions.DependencyInjection.Unity.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.Unity.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection.Unity.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.Unity.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 


### PR DESCRIPTION
Reguires #11 to ber merged first to make linux tests to not blow up