### PR TITLE
Fixed NSB minor version

### DIFF
--- a/src/NServiceBus.Extensions.DependencyInjection/NServiceBus.Extensions.DependencyInjection.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection/NServiceBus.Extensions.DependencyInjection.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
-    <PackageReference Include="NServiceBus" Version="[7.2.3, 8.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[7.2.2, 8.0.0)" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.5.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
The library has a dependency to NSB where the minor version is the 7.2.3 that doesn't exist (see here https://github.com/Particular/NServiceBus.Extensions.DependencyInjection/blob/master/src/NServiceBus.Extensions.DependencyInjection/NServiceBus.Extensions.DependencyInjection.csproj#L15)

As you can see in these screenshot the latest one of NSB in the 7.2.2.

<img width="1152" alt="Screenshot 2020-02-26 at 15 43 18" src="https://user-images.githubusercontent.com/758620/75355806-5a8e0780-58af-11ea-88e9-953b579b7399.png">

<img width="1061" alt="Screenshot 2020-02-26 at 15 43 35" src="https://user-images.githubusercontent.com/758620/75355820-5f52bb80-58af-11ea-8c35-3367300caccf.png">
