### PR TITLE
Use Microsoft's default DI abstraction implementation for the acceptance tests

### DIFF
--- a/src/NServiceBus.Extensions.DependencyInjection.AcceptanceTests/DefaultServer.cs
+++ b/src/NServiceBus.Extensions.DependencyInjection.AcceptanceTests/DefaultServer.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Threading.Tasks;
     using AcceptanceTesting.Support;
+    using Microsoft.Extensions.DependencyInjection;
 
     public class DefaultServer : ExternallyManagedContainerServer
     {
@@ -10,6 +11,7 @@
         {
             return base.GetConfiguration(runDescriptor, endpointCustomizationConfiguration, endpointConfiguration =>
             {
+                endpointConfiguration.UseContainer(new DefaultServiceProviderFactory());
                 configurationBuilderCustomization(endpointConfiguration);
             });
         }


### PR DESCRIPTION
This change will cause the tests to fail as the default implementation does not support property injection but many of the acceptance tests require property injection.