### PR TITLE
the next Lamar.Microsoft.DependencyInjection patch will restore .NET FX support

### DIFF
--- a/src/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests/NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="4.3.1" />
+    <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="4.3.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.2.4" />
   </ItemGroup>
 


### PR DESCRIPTION
See https://github.com/JasperFx/lamar/commit/17fd68e3ef9062040a090a3921c0e3eded1d6ad3#commitcomment-40828873

Revert "drop the net461 TFM from NServiceBus.Extensions.DependencyInjection.Lamar.AcceptanceTests"

This reverts commit 887fec810b2d20157c18011b4d5fd948e34ad1ca.

Revert "Bump Lamar.Microsoft.DependencyInjection from 4.3.0 to 4.3.1"

This reverts commit 2a71531c5bbcefff906a4dd608bf293e71dd20a7.