### PR TITLE
Support for Microsoft.Extensions.DependencyInjection 6.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
-            3.1.x   
       - name: Build
         run: dotnet build src --configuration Release
       - name: Upload packages

--- a/src/AcceptanceTests/AcceptanceTests.csproj
+++ b/src/AcceptanceTests/AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <NoWarn>$(NoWarn);SYSLIB0021</NoWarn>
   </PropertyGroup>

--- a/src/AcceptanceTests/AcceptanceTests.csproj
+++ b/src/AcceptanceTests/AcceptanceTests.csproj
@@ -16,10 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AcceptanceTests/AcceptanceTests.csproj
+++ b/src/AcceptanceTests/AcceptanceTests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" GeneratePathProperty="True" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.8.0" GeneratePathProperty="True" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AcceptanceTests/AcceptanceTests.csproj
+++ b/src/AcceptanceTests/AcceptanceTests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" GeneratePathProperty="True" />
   </ItemGroup>
 

--- a/src/Autofac.AcceptanceTests/Autofac.AcceptanceTests.csproj
+++ b/src/Autofac.AcceptanceTests/Autofac.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <NoWarn>$(NoWarn);SYSLIB0021</NoWarn>
   </PropertyGroup>

--- a/src/Autofac.AcceptanceTests/Autofac.AcceptanceTests.csproj
+++ b/src/Autofac.AcceptanceTests/Autofac.AcceptanceTests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" GeneratePathProperty="True" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.8.0" GeneratePathProperty="True" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Autofac.AcceptanceTests/Autofac.AcceptanceTests.csproj
+++ b/src/Autofac.AcceptanceTests/Autofac.AcceptanceTests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" GeneratePathProperty="True" />
   </ItemGroup>
 

--- a/src/Autofac.AcceptanceTests/Autofac.AcceptanceTests.csproj
+++ b/src/Autofac.AcceptanceTests/Autofac.AcceptanceTests.csproj
@@ -17,10 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Autofac.AcceptanceTests/Autofac.AcceptanceTests.csproj
+++ b/src/Autofac.AcceptanceTests/Autofac.AcceptanceTests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.8.0" GeneratePathProperty="True" />
   </ItemGroup>

--- a/src/CastleWindsor.AcceptanceTests/CastleWindsor.AcceptanceTests.csproj
+++ b/src/CastleWindsor.AcceptanceTests/CastleWindsor.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <NoWarn>$(NoWarn);SYSLIB0021</NoWarn>
   </PropertyGroup>

--- a/src/CastleWindsor.AcceptanceTests/CastleWindsor.AcceptanceTests.csproj
+++ b/src/CastleWindsor.AcceptanceTests/CastleWindsor.AcceptanceTests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="3.3.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" GeneratePathProperty="True" />
   </ItemGroup>
 

--- a/src/CastleWindsor.AcceptanceTests/CastleWindsor.AcceptanceTests.csproj
+++ b/src/CastleWindsor.AcceptanceTests/CastleWindsor.AcceptanceTests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="3.3.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" GeneratePathProperty="True" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.8.0" GeneratePathProperty="True" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CastleWindsor.AcceptanceTests/CastleWindsor.AcceptanceTests.csproj
+++ b/src/CastleWindsor.AcceptanceTests/CastleWindsor.AcceptanceTests.csproj
@@ -11,16 +11,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="3.3.1" />
+    <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="3.4.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.8.0" GeneratePathProperty="True" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lamar.AcceptanceTests/DefaultServer.cs
+++ b/src/Lamar.AcceptanceTests/DefaultServer.cs
@@ -4,6 +4,7 @@
     using System.Threading.Tasks;
     using AcceptanceTesting.Support;
     using Lamar;
+    using Lamar.Microsoft.DependencyInjection;
 
     public class DefaultServer : ExternallyManagedContainerServer
     {

--- a/src/Lamar.AcceptanceTests/Lamar.AcceptanceTests.csproj
+++ b/src/Lamar.AcceptanceTests/Lamar.AcceptanceTests.csproj
@@ -10,16 +10,10 @@
     <ProjectReference Include="..\NServiceBus.Extensions.DependencyInjection\NServiceBus.Extensions.DependencyInjection.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
-  </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="4.1.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" GeneratePathProperty="True" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lamar.AcceptanceTests/Lamar.AcceptanceTests.csproj
+++ b/src/Lamar.AcceptanceTests/Lamar.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <NoWarn>$(NoWarn);SYSLIB0021</NoWarn>
   </PropertyGroup>

--- a/src/Lamar.AcceptanceTests/Lamar.AcceptanceTests.csproj
+++ b/src/Lamar.AcceptanceTests/Lamar.AcceptanceTests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" GeneratePathProperty="True" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.8.0" GeneratePathProperty="True" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="8.0.1" />
   </ItemGroup>

--- a/src/Lamar.AcceptanceTests/Lamar.AcceptanceTests.csproj
+++ b/src/Lamar.AcceptanceTests/Lamar.AcceptanceTests.csproj
@@ -17,10 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Extensions.DependencyInjection/NServiceBus.Extensions.DependencyInjection.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection/NServiceBus.Extensions.DependencyInjection.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="NServiceBus" Version="[7.2.3, 8.0.0)" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="2.0.0" PrivateAssets="All" />

--- a/src/NServiceBus.Extensions.DependencyInjection/NServiceBus.Extensions.DependencyInjection.csproj
+++ b/src/NServiceBus.Extensions.DependencyInjection/NServiceBus.Extensions.DependencyInjection.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="NServiceBus" Version="[7.2.3, 8.0.0)" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.1" PrivateAssets="All" />
-    <PackageReference Include="Particular.Packaging" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="2.2.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/StructureMap.AcceptanceTests/StructureMap.AcceptanceTests.csproj
+++ b/src/StructureMap.AcceptanceTests/StructureMap.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <NoWarn>$(NoWarn);SYSLIB0021</NoWarn>
   </PropertyGroup>

--- a/src/StructureMap.AcceptanceTests/StructureMap.AcceptanceTests.csproj
+++ b/src/StructureMap.AcceptanceTests/StructureMap.AcceptanceTests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" GeneratePathProperty="True" />
     <PackageReference Include="StructureMap.Microsoft.DependencyInjection" Version="2.0.0" />
   </ItemGroup>

--- a/src/StructureMap.AcceptanceTests/StructureMap.AcceptanceTests.csproj
+++ b/src/StructureMap.AcceptanceTests/StructureMap.AcceptanceTests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.5.0" GeneratePathProperty="True" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.8.0" GeneratePathProperty="True" />
     <PackageReference Include="StructureMap.Microsoft.DependencyInjection" Version="2.0.0" />
   </ItemGroup>
 

--- a/src/StructureMap.AcceptanceTests/StructureMap.AcceptanceTests.csproj
+++ b/src/StructureMap.AcceptanceTests/StructureMap.AcceptanceTests.csproj
@@ -17,10 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -13,16 +13,16 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="NServiceBus" Version="7.2.3" />
-    <PackageReference Include="Particular.Approvals" Version="0.2.0" />
+    <PackageReference Include="NServiceBus" Version="7.8.0" />
+    <PackageReference Include="Particular.Approvals" Version="0.3.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="NServiceBus" Version="7.2.3" />
     <PackageReference Include="Particular.Approvals" Version="0.2.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />

--- a/src/Unity.AcceptanceTests/Unity.AcceptanceTests.csproj
+++ b/src/Unity.AcceptanceTests/Unity.AcceptanceTests.csproj
@@ -11,15 +11,15 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.2.3" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.8.0" />
     <PackageReference Include="Unity.Microsoft.DependencyInjection" Version="5.11.5" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Unity.AcceptanceTests/Unity.AcceptanceTests.csproj
+++ b/src/Unity.AcceptanceTests/Unity.AcceptanceTests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.2.3" />
     <PackageReference Include="Unity.Microsoft.DependencyInjection" Version="5.11.5" />
   </ItemGroup>

--- a/src/Unity.AcceptanceTests/Unity.AcceptanceTests.csproj
+++ b/src/Unity.AcceptanceTests/Unity.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 


### PR DESCRIPTION
Originally reported by @simoncropp

This brings in support for `Microsoft.Extensions.DependencyInjection` 6.0.0. ServiceCollection has been moved into the abstractions at some point. When trying to use `NServiceBus.Extensions.DependencyInjection` with `Microsoft.Extensions.DependencyInjection` 6.0.0 


```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFramework>net6.0</TargetFramework>
    <OutputType>Exe</OutputType>
    <LangVersion>7.3</LangVersion>
  </PropertyGroup>
  <ItemGroup>
    <PackageReference Include="NServiceBus" Version="7.8.0" />
    <PackageReference Include="NServiceBus.Extensions.DependencyInjection" Version="1.0.1" />
    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
  </ItemGroup>
</Project>
```

the following error occurs

```
  Program.cs(4, 20): [CS0433] The type 'ServiceCollection' exists in both 'Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' and 'Microsoft.Extensions.DependencyInjection, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'
```
